### PR TITLE
adding time and currency decorators, some basic tests also

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+from utils.common import minutes_to_hours, currency_usd
+
+# run via PYTHONPATH=. pytest tests/test_utils.py
+
+
+def test_decorator_time():
+
+    @minutes_to_hours
+    def test_format_time():
+        time_in_minutes = 90.5
+        return time_in_minutes
+
+    assert test_format_time() == {'hours': 1, 'minutes': 30.5}
+
+
+def test_decorator_usd():
+
+    @currency_usd
+    def test_usd_currency():
+        cost = 08.20
+        return cost
+
+    assert test_usd_currency() == "%0.2f" % 8.2

--- a/utils/common.py
+++ b/utils/common.py
@@ -1,0 +1,25 @@
+def currency_usd(func):
+    '''
+    ensures currency formating is consistent
+    '''
+
+    def wrapper(*args, **kwargs):
+        amount = func(*args, **kwargs)
+        if amount is None:
+            return ("%0.2f" % float(0))
+        else:
+            return ("%0.2f" % float(amount))
+    return wrapper
+
+
+def minutes_to_hours(func):
+    '''
+    ensures minutes are always divided into
+    amount of hours and minutes cleanly
+    '''
+
+    def wrapper(*args, **kwargs):
+        m = func(*args, **kwargs)
+        h, m = divmod(m, 60)
+        return {'hours': int(h), 'minutes': float(m)}
+    return wrapper


### PR DESCRIPTION
Adds decorators into a utils/common file for use with currency and time handling

For currency, we ensure numbers are returned in an d.cc format, no leading zeros and double digits after decimal

For time handling, we use divmod to return a dictionary with hours and minutes. This always gives something like 1 hour and 30 minutes, vs 1.5 hours... since 1.5 hours and 1 hour and 50 minutes are completely different.