### PR TITLE
Update app requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Provides decorators, classes, and functions specific to Skatetrax. Additionally,
 
 ## Requires
 ``` bash
-sudo yum install python3 python3-pip
+sudo dnf install python3.12-devel python3-pip
 pip install pipenv --user
 ```
 


### PR DESCRIPTION
* Install python3.12-devel, rather than python3, because this app declares Python 3.12 as a dependency. Python 3.13, Python 3.11, etc will not work. Also, the `-devel` package provides what is needed to compile psycopg2.
* Install packages with dnf, not yum. RHEL 8+ and Fedora both use dnf.