### PR TITLE
fix for session dates appearing a day behind, updates how date and time is submitted to the db, how the user's tz is applied in the view

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skatetrax-core"
-version = "4.1.4"
+version = "4.1.5"
 description = "Core logic for Skatetrax"
 authors = [{ name = "Ashley L Young", email = "burning.rose85@gmail.com" }]
 readme = "README.md"

--- a/skatetrax/models/ops/data_aggregates.py
+++ b/skatetrax/models/ops/data_aggregates.py
@@ -7,7 +7,12 @@ import calendar
 from ...models.cyberconnect2 import create_session
 from ...utils.timeframe_generator import TIMEFRAMES
 from ...utils.common import minutes_to_hours, currency_usd
-from ...utils.tz import today_in_tz, utc_to_local, resolve_tz
+from ...utils.tz import (
+    today_in_tz,
+    utc_to_local,
+    resolve_tz,
+    utc_naive_range_for_inclusive_local_dates,
+)
 
 from ..t_equip import uSkateConfig, uSkaterBlades, uSkaterBoots
 from ..t_skaterMeta import uSkaterConfig
@@ -37,6 +42,11 @@ class SkaterAggregates:
     def _get_session(self):
         return self.external_session or create_session()
 
+    def _utc_bounds_for_calendar(self, start_date: date, end_date: date):
+        """Inclusive local calendar dates → naive UTC half-open range for Ice_Time.date."""
+        return utc_naive_range_for_inclusive_local_dates(
+            start_date, end_date, resolve_tz(None, self.tz)
+        )
 
     def aggregate(self, model, field, start_date=None, end_date=None, ice_type_ids=None):
         """Sum field for this skater, optionally filtered by start/end dates and ice_type."""
@@ -44,7 +54,8 @@ class SkaterAggregates:
             column = getattr(model, field)
             q = s.query(func.sum(column)).filter(model.uSkaterUUID == self.uSkaterUUID)
             if start_date and end_date:
-                q = q.filter(model.date >= start_date, model.date <= end_date)
+                lo, hi_excl = self._utc_bounds_for_calendar(start_date, end_date)
+                q = q.filter(model.date >= lo, model.date < hi_excl)
             if ice_type_ids:
                 q = q.filter(model.skate_type.in_(ice_type_ids))
             result = q.scalar() or 0
@@ -259,7 +270,8 @@ class SkaterAggregates:
             q = s.query(func.count(Ice_Time.ice_time_id)).filter(
                 Ice_Time.uSkaterUUID == self.uSkaterUUID)
             if start and end:
-                q = q.filter(Ice_Time.date >= start, Ice_Time.date <= end)
+                lo, hi_excl = self._utc_bounds_for_calendar(start, end)
+                q = q.filter(Ice_Time.date >= lo, Ice_Time.date < hi_excl)
             return q.scalar()
 
     def distinct_coach_count(self, timeframe=None):
@@ -271,7 +283,8 @@ class SkaterAggregates:
                 Ice_Time.uSkaterUUID == self.uSkaterUUID,
                 Ice_Time.coach_time > 0)
             if start and end:
-                q = q.filter(Ice_Time.date >= start, Ice_Time.date <= end)
+                lo, hi_excl = self._utc_bounds_for_calendar(start, end)
+                q = q.filter(Ice_Time.date >= lo, Ice_Time.date < hi_excl)
             return q.scalar()
 
     def distinct_rink_count(self, timeframe=None):
@@ -282,7 +295,8 @@ class SkaterAggregates:
             q = s.query(func.count(func.distinct(Ice_Time.rink_id))).filter(
                 Ice_Time.uSkaterUUID == self.uSkaterUUID)
             if start and end:
-                q = q.filter(Ice_Time.date >= start, Ice_Time.date <= end)
+                lo, hi_excl = self._utc_bounds_for_calendar(start, end)
+                q = q.filter(Ice_Time.date >= lo, Ice_Time.date < hi_excl)
             return q.scalar()
 
     def earliest_session_date(self):
@@ -306,7 +320,8 @@ class SkaterAggregates:
                 .filter(Ice_Time.uSkaterUUID == self.uSkaterUUID)
             )
             if start and end:
-                q = q.filter(Ice_Time.date >= start, Ice_Time.date <= end)
+                lo, hi_excl = self._utc_bounds_for_calendar(start, end)
+                q = q.filter(Ice_Time.date >= lo, Ice_Time.date < hi_excl)
             rows = q.distinct().all()
             return [r[0] for r in rows if r[0]]
 

--- a/skatetrax/models/ops/data_tables.py
+++ b/skatetrax/models/ops/data_tables.py
@@ -3,8 +3,7 @@ from sqlalchemy import func
 
 from ..cyberconnect2 import create_session, get_engine
 
-from ...utils.common import Timelines
-from ...utils.tz import utc_to_local
+from ...utils.tz import utc_to_local, today_in_tz, utc_naive_range_for_inclusive_local_dates, resolve_tz
 
 from ..t_ice_time import Ice_Time
 from ..t_locations import Locations
@@ -262,11 +261,15 @@ class Sessions_Tables():
     def ice_time_current_month(uSkaterUUID, tz=None, session=None):
         '''
         lists all ice sessions of a particular skater via uSkaterUUID
-        for the current month.
+        for the current month (interpreted in tz, or UTC when tz is omitted).
         Returns a pandas dataframe containing joined data of:
         date, ice session meta, coach meta, rink meta.
         '''
-        tl = Timelines.current_month(tz=tz)
+        today = today_in_tz(tz)
+        month_start = today.replace(day=1)
+        lo, hi_excl = utc_naive_range_for_inclusive_local_dates(
+            month_start, today, resolve_tz(None, tz)
+        )
 
         def _run(sess, engine):
             return pd.read_sql_query(
@@ -285,8 +288,8 @@ class Sessions_Tables():
                     Locations.rink_tz,
                 )
                 .where(Ice_Time.uSkaterUUID == uSkaterUUID)
-                .filter(Ice_Time.date >= tl['last'])
-                .filter(Ice_Time.date <= tl['first'])
+                .filter(Ice_Time.date >= lo)
+                .filter(Ice_Time.date < hi_excl)
                 .outerjoin(Locations, Ice_Time.rink_id == Locations.rink_id)
                 .outerjoin(IceType, Ice_Time.skate_type == IceType.ice_type_id)
                 .outerjoin(Coaches, Ice_Time.coach_id == Coaches.coach_id)

--- a/skatetrax/utils/tz.py
+++ b/skatetrax/utils/tz.py
@@ -1,5 +1,59 @@
-from datetime import datetime, date
+from datetime import datetime, date, time, timedelta
 from zoneinfo import ZoneInfo
+
+
+def _zoneinfo_or_utc(tz_name):
+    """Resolve an IANA name; invalid or empty values fall back to UTC."""
+    if not tz_name:
+        return ZoneInfo("UTC")
+    try:
+        return ZoneInfo(tz_name)
+    except Exception:
+        return ZoneInfo("UTC")
+
+
+def intent_local_calendar_day_for_legacy_utc_midnight(
+    stored_naive_utc: datetime, tz_name: str | None
+) -> date:
+    """
+    Legacy rows were often saved as UTC midnight. That instant can fall on the *previous*
+    local calendar evening (e.g. Americas). Infer the skating day the user meant:
+
+    - If local calendar date < stored UTC date → intent is (local date + 1 day).
+    - Otherwise (UTC user, or same calendar date in Asia) → intent is stored UTC date.
+
+    Used by admin migration; new inserts should use local_date_start_as_utc_naive from the
+    form date directly (no bump).
+    """
+    stored_d = stored_naive_utc.date()
+    local_d = utc_to_local(stored_naive_utc, resolve_tz(None, tz_name)).date()
+    if local_d < stored_d:
+        return local_d + timedelta(days=1)
+    return stored_d
+
+
+def local_date_start_as_utc_naive(local_day: date, tz_name: str | None) -> datetime:
+    """
+    Convert a calendar date in the skater's (or rink's) timezone to the
+    UTC instant at the start of that local day, returned as naive UTC for
+    storage alongside existing naive-UTC timestamps.
+    """
+    z = _zoneinfo_or_utc(tz_name)
+    start_local = datetime.combine(local_day, time.min, tzinfo=z)
+    return start_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+
+
+def utc_naive_range_for_inclusive_local_dates(
+    start_d: date, end_d: date, tz_name: str | None
+) -> tuple[datetime, datetime]:
+    """
+    Map an inclusive local calendar range [start_d, end_d] to half-open UTC
+    [start_utc_naive, end_utc_naive) for filtering TIMESTAMP columns that
+    store naive UTC.
+    """
+    lo = local_date_start_as_utc_naive(start_d, tz_name)
+    hi_excl = local_date_start_as_utc_naive(end_d + timedelta(days=1), tz_name)
+    return lo, hi_excl
 
 
 def resolve_tz(rink_tz=None, user_tz=None):

--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -1,3 +1,4 @@
+import calendar
 import pytest
 from uuid import UUID as PyUUID
 from datetime import datetime, date, timezone, timedelta
@@ -6,7 +7,9 @@ from unittest.mock import patch
 from skatetrax.models.ops.data_aggregates import (
     SkaterAggregates, uMaintenanceV4, UserMeta, Equipment,
 )
+from skatetrax.models.ops.data_tables import Sessions_Tables
 from skatetrax.models.t_ice_time import Ice_Time
+from skatetrax.utils.tz import utc_to_local
 from skatetrax.models.t_maint import uSkaterMaint
 from skatetrax.models.t_equip import uSkaterBlades, uSkateConfig
 
@@ -168,6 +171,78 @@ class TestKnownSessionData:
 
         sa = SkaterAggregates(NEW_USER_UUID, session=seeded_session)
         assert sa.coach_cost("total") == "77.00"
+
+
+class TestIceTimeTzAlignment:
+    """Stored timestamps are naive UTC; bounds use the skater's calendar TZ."""
+
+    def test_month_bucket_matches_local_calendar_not_utc_date(self, seeded_session):
+        """UTC midnight March 1 is still Feb 28 evening in US/Eastern."""
+        _add_session(seeded_session, datetime(2026, 3, 1, 0, 0, 0), 45, 0, 0)
+        seeded_session.flush()
+
+        eastern = SkaterAggregates(
+            NEW_USER_UUID, session=seeded_session, tz="America/New_York"
+        )
+        assert eastern.aggregate(Ice_Time, "ice_time", date(2026, 2, 1), date(2026, 2, 28)) == 45
+        assert eastern.aggregate(Ice_Time, "ice_time", date(2026, 3, 1), date(2026, 3, 31)) == 0
+
+        utc_skater = SkaterAggregates(NEW_USER_UUID, session=seeded_session, tz="UTC")
+        assert utc_skater.aggregate(Ice_Time, "ice_time", date(2026, 3, 1), date(2026, 3, 31)) == 45
+
+
+class TestAggregateParityWithSessionTable:
+    """
+    End-to-end check: the same naive-UTC row is counted in exactly one skater-calendar
+    month in aggregates and shows the same (year, month) after the session-table
+    UTC→local conversion (seed rink uses America/New_York; pass the same tz so
+    aggregate bounds match display).
+    """
+
+    _SKATER_TZ = "America/New_York"
+
+    @pytest.mark.parametrize(
+        "stored_utc_naive",
+        [
+            # Original bug shape: naive “Mar 1 00:00 UTC” → Eastern Feb 28 evening
+            datetime(2026, 3, 1, 0, 0, 0),
+            # Same calendar day in Eastern (after conversion)
+            datetime(2026, 3, 1, 7, 0, 0),
+        ],
+    )
+    def test_one_session_one_month_aggregate_matches_table_display(
+        self, seeded_session, stored_utc_naive,
+    ):
+        mins = 45
+        _add_session(seeded_session, stored_utc_naive, mins, 0, 0)
+        seeded_session.flush()
+
+        # Reference: local calendar month as the UI table sees it (rink TZ matches skater here)
+        local = utc_to_local(stored_utc_naive, self._SKATER_TZ)
+        expect_y, expect_m = local.year, local.month
+
+        sa = SkaterAggregates(
+            NEW_USER_UUID, session=seeded_session, tz=self._SKATER_TZ
+        )
+        start_d = date(expect_y, expect_m, 1)
+        end_d = date(
+            expect_y, expect_m, calendar.monthrange(expect_y, expect_m)[1]
+        )
+        assert sa.aggregate(Ice_Time, "ice_time", start_d, end_d) == mins
+
+        # Neighbour month must not pick up this row (single-session sanity)
+        ny, nm = (expect_y + 1, 1) if expect_m == 12 else (expect_y, expect_m + 1)
+        n_last = calendar.monthrange(ny, nm)[1]
+        assert (
+            sa.aggregate(Ice_Time, "ice_time", date(ny, nm, 1), date(ny, nm, n_last))
+            == 0
+        )
+
+        df = Sessions_Tables.ice_time(
+            NEW_USER_UUID, tz=self._SKATER_TZ, session=seeded_session
+        )
+        shown = df.iloc[0]["date"]
+        assert (shown.year, shown.month) == (expect_y, expect_m)
 
 
 class TestTimeframeFiltering:

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -3,7 +3,14 @@ from datetime import datetime, date
 from zoneinfo import ZoneInfo
 from unittest.mock import patch
 
-from skatetrax.utils.tz import resolve_tz, utc_to_local, today_in_tz
+from skatetrax.utils.tz import (
+    resolve_tz,
+    utc_to_local,
+    today_in_tz,
+    local_date_start_as_utc_naive,
+    utc_naive_range_for_inclusive_local_dates,
+    intent_local_calendar_day_for_legacy_utc_midnight,
+)
 
 # run via: PYTHONPATH=. pytest tests/test_tz.py -v
 
@@ -46,6 +53,50 @@ class TestUtcToLocal:
         utc_dt = datetime(2026, 7, 15, 16, 0, 0)
         result = utc_to_local(utc_dt, "America/New_York")
         assert result.hour == 12  # EDT is UTC-4
+
+
+class TestLocalDateToUtcNaive:
+
+    def test_eastern_midnight_is_utc_offset(self):
+        d = date(2026, 2, 28)
+        utc_naive = local_date_start_as_utc_naive(d, "America/New_York")
+        assert utc_naive == datetime(2026, 2, 28, 5, 0, 0)
+
+    def test_utc_identity(self):
+        d = date(2026, 3, 1)
+        assert local_date_start_as_utc_naive(d, "UTC") == datetime(2026, 3, 1, 0, 0, 0)
+
+
+class TestIntentLocalDayLegacyMidnight:
+
+    def test_eastern_utc_midnight_bumps_to_stored_utc_date(self):
+        # Mar 3 00:00 UTC = Sunday PM US/Eastern → user meant Mon Mar 3
+        d = intent_local_calendar_day_for_legacy_utc_midnight(
+            datetime(2026, 3, 3, 0, 0, 0), "America/New_York"
+        )
+        assert d == date(2026, 3, 3)
+
+    def test_utc_skater_no_bump(self):
+        d = intent_local_calendar_day_for_legacy_utc_midnight(
+            datetime(2026, 3, 3, 0, 0, 0), "UTC"
+        )
+        assert d == date(2026, 3, 3)
+
+    def test_tokyo_same_calendar_no_bump(self):
+        d = intent_local_calendar_day_for_legacy_utc_midnight(
+            datetime(2026, 3, 3, 0, 0, 0), "Asia/Tokyo"
+        )
+        assert d == date(2026, 3, 3)
+
+
+class TestUtcNaiveRangeInclusive:
+
+    def test_february_span_new_york(self):
+        lo, hi_excl = utc_naive_range_for_inclusive_local_dates(
+            date(2026, 2, 1), date(2026, 2, 28), "America/New_York"
+        )
+        edge = datetime(2026, 3, 1, 0, 0, 0)
+        assert lo <= edge < hi_excl
 
 
 class TestTodayInTz:


### PR DESCRIPTION
Addresses the issue where time submitted for March 3 2026 was showing in the session table as Feb 28 2026. Looking through the data, this was a common issue, now fixed.